### PR TITLE
Remove Bash as a runtime dependency

### DIFF
--- a/3.10/x86/pip-wrapper
+++ b/3.10/x86/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.10/x86/python-wrapper
+++ b/3.10/x86/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/3.10/x86_64/pip-wrapper
+++ b/3.10/x86_64/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.10/x86_64/python-wrapper
+++ b/3.10/x86_64/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/3.11/x86/pip-wrapper
+++ b/3.11/x86/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.11/x86/python-wrapper
+++ b/3.11/x86/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/3.11/x86_64/pip-wrapper
+++ b/3.11/x86_64/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.11/x86_64/python-wrapper
+++ b/3.11/x86_64/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/3.12/x86/pip-wrapper
+++ b/3.12/x86/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.12/x86/python-wrapper
+++ b/3.12/x86/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/3.12/x86_64/pip-wrapper
+++ b/3.12/x86_64/pip-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -28,7 +28,7 @@ hack_real_pip_shebang() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    export SCRIPT_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
     
     # Find the REAL_PYTHON and REAL_PIP

--- a/3.12/x86_64/python-wrapper
+++ b/3.12/x86_64/python-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ bootstraping_libc() {
 
 # Function to set up environment variables
 setup_environment() {
-    export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    export SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     export INSTALL_PREFIX="$SCRIPT_DIR/../"
 
     # Find the REAL_PYTHON

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ standalone Python is designed to work seamlessly across all Linux platforms.
 - Run the Python script with the standalone Python:
     - `./opt/python/bin/python ./your_script.py`
 
-## Currently Only One Dependency:
-- bash
-
 # License
 Any codes were downloaded from links, follow the license of the original project.
 


### PR DESCRIPTION
This removes Bash as a runtime dependency for the project. Bash is still needed to build the releases. Fixes #10.